### PR TITLE
Refactor color scheme handling and key bindings initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Add the following to the bottom of your config:
 local wezterm = require("wezterm")
 local modal = wezterm.plugin.require("https://github.com/MLFlexer/modal.wezterm")
 modal.apply_to_config(config)
+modal.set_default_keys(config)
 ```
 This will add the keybindings to enter and exit modes:
 * `ALT-u` to enter UI mode from normal mode

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -186,8 +186,12 @@ local function apply_to_config(config)
 		mod_seperator = "-",
 	}
 
-	if config.colors == nil then
-		config.colors = wezterm.color.get_default_colors()
+	if not config.colors then
+    if config.color_scheme then
+      config.colors = wezterm.color.get_builtin_schemes()[config.color_scheme]
+    else
+      config.colors = wezterm.color.get_default_colors()
+    end
 	end
 
 	local colors = {

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -221,26 +221,27 @@ local function apply_to_config(config)
 	add_mode("Visual", {}, status_text)
 
 	config.key_tables = key_tables
+end
 
-	if config.keys == nil then
-		config.keys = {}
-	end
-
-	table.insert(config.keys, {
-		key = "n",
-		mods = "ALT",
-		action = activate_mode("Scroll"),
-	})
-	table.insert(config.keys, {
-		key = "u",
-		mods = "ALT",
-		action = activate_mode("UI"),
-	})
-	table.insert(config.keys, {
-		key = "c",
-		mods = "ALT",
-		action = activate_mode("copy_mode"),
-	})
+local function set_default_keys(config)
+  if config.keys == nil then
+      config.keys = {}
+  end
+  table.insert(config.keys, {
+    key = "n",
+    mods = "ALT",
+    action = activate_mode("Scroll"),
+  })
+  table.insert(config.keys, {
+    key = "u",
+    mods = "ALT",
+    action = activate_mode("UI"),
+  })
+  table.insert(config.keys, {
+    key = "c",
+    mods = "ALT",
+    action = activate_mode("copy_mode"),
+  })
 end
 
 return {
@@ -254,6 +255,7 @@ return {
 	key_tables = key_tables,
 	enable_defaults = enable_defaults,
 	apply_to_config = apply_to_config,
+	set_default_keys = set_default_keys,
 	activate_mode = activate_mode,
 	exit_mode = exit_mode,
 	exit_all_modes = exit_all_modes,


### PR DESCRIPTION
**Description:**
This PR introduces several improvements to the plugin's initialization logic:

1. **Color Scheme Fixes**  
   - Previously, if users only set `config.color_scheme` without `config.colors`, the plugin would ignore the scheme and fall back to default colors.  
   - Now, if `config.color_scheme` is defined, it properly loads the built-in scheme instead of defaulting.  
   - This ensures users who rely on `color_scheme` (a common Wezterm setting) get the correct colors without needing to manually define `config.colors`.  

2. **Optional Default Keybinds**  
   - Before, the plugin automatically added default keybindings (like `ALT+n`, `ALT+u`, `ALT+c`) even if users didn’t want them.  
   - Now, keybind initialization is moved into a separate `set_default_keys(config)` function, which must be called explicitly.  
   - This gives users full control—they can:  
     - Skip calling it to avoid default keybinds entirely.  
     - Call it once to apply defaults.  
     - Modify the keys afterward if they want partial overrides.  

### **Why This Matters**  
- **Fixes silent color issues** – Users who only set `color_scheme` (very common) no longer get unexpected default colors.  
- **More flexible keybinds** – Users can now opt-in to defaults instead of having them forced.  

### **Migration Notes**  
- **No changes needed** if you already define `config.colors` manually.  
- If you **want the old default keybinds**, add `set_default_keys(config)` after applying the plugin.  
- If you **don’t want default keybinds**, do nothing—they won’t be added automatically anymore.  